### PR TITLE
Add first batch of important documents

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,45 @@
+# Dronecode Foundation Contributor Covenant Code of Conduct v1.0
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Dronecode Foundation Project, Standards maintainers, project participants, and contributors (collectively, "participants") are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+The steering committee of the Dronecode Foundation has the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+All participants have determined that The Linux Foundation is the most optimal organization to shepherd the development of this project. Participants acknowledge and agree to The Linux Foundation's exclusive right to use "Dronecode Foundation" and any other names and trademarks associated with the Dronecode Foundation and Dronecode Foundation Standards and to authorize others’ use of the marks, establish guidelines for such use, and to delegate these responsibilities. Participants agree not to take any action inconsistent with such rights and to cooperate in any action which The Linux Foundation deems necessary or desirable to prevent confusion or establish or preserve these rights. Participants will not independently adopt, use, or attempt to register any trademarks or trade names that are confusingly similar to these names.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Dronecode Foundation Chairman (at lorenz@px4.io), or if the complaint involves the Chairman, a member of the steering committee. All complaints will result ina  response that is deemed necessary and appropirate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers, contributors or participants who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by the steering committee.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html). For answers to common questions about this code of conduct, see [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# foundation
+# Dronecode Foundation Bylaws and Legal Documents
+
+* [Droneocde Foundation Bylaws](https://www.dronecode.org/bylaws/)
+* Dronecode Foundation Code of Conduct
+
+# Membership Documents
+* [Dronecode Foundation Membership](https://www.dronecode.org/membership/)
+
+# Contributing to this repo
+This repository is intended to be edited by Dronecode Foundation staff and maintainers of the top-level open-source projects hosted under the Foundation.
+
+If you have any questions regarding the Dronecode Foundation please email [rroche@linuxfoundation.org](mailto:rroche@linuxfoundation.org).


### PR DESCRIPTION
Includes a readme with links to Dronecode Foundation Bylaws, and Membership information, as well as our Code of Conduct that should be followed through out all of our official channels